### PR TITLE
ActiveStorageを使ってユーザーアイコンを登録・更新できるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,6 +294,7 @@ DEPENDENCIES
   devise-i18n
   faker
   i18n_generators
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction]
+    keys = %i[name postal_code address self_introduction image]
     devise_parameter_sanitizer.permit(:sign_up, keys: keys)
     devise_parameter_sanitizer.permit(:account_update, keys: keys)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 
 class UsersController < ApplicationController
   def index
-    @users = User.order(:id).page(params[:page])
+    @users = User.order(:id).page(params[:page]).includes(image_attachment: :blob)
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_one_attached :image
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,17 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_one_attached :image
+
+  validate :check_content_type, if: :attached?
+
+  def check_content_type
+    extension = ['image/png', 'image/jpeg', 'image/gif']
+    errors.add(:image, 'の拡張子が間違っています。.png .jpg .jpeg .gifのいずれかにしてください。') unless image.content_type.in?(extension)
+  end
+
+  private
+
+  def attached?
+    image.attached?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User < ApplicationRecord
   validate :check_content_type, if: :attached?
 
   def check_content_type
-    extension = ['image/png', 'image/jpeg', 'image/gif']
-    errors.add(:image, 'の拡張子が間違っています。.png .jpg .jpeg .gifのいずれかにしてください。') unless image.content_type.in?(extension)
+    content_types = ['image/png', 'image/jpeg', 'image/gif']
+    errors.add(:image, 'の拡張子が間違っています。.png .jpg .jpeg .gifのいずれかにしてください。') unless image.content_type.in?(content_types)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   has_one_attached :image
 
-  validate :check_content_type, if: :attached?
+  validate :check_content_type, if: :image_attached?
 
   def check_content_type
     content_types = ['image/png', 'image/jpeg', 'image/gif']
@@ -15,7 +15,7 @@ class User < ApplicationRecord
 
   private
 
-  def attached?
+  def image_attached?
     image.attached?
   end
 end

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -17,3 +17,8 @@
   <%= f.label :self_introduction %>
   <%= f.text_area :self_introduction %>
 </div>
+
+<div class="field">
+  <%= f.label :image %>
+  <%= f.file_field :image %>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,6 +3,7 @@
 <table>
   <thead>
     <tr>
+      <th><%= User.human_attribute_name(:image) %></th>
       <th><%= User.human_attribute_name(:email) %></th>
       <th><%= User.human_attribute_name(:name) %></th>
       <th><%= User.human_attribute_name(:postal_code) %></th>
@@ -14,6 +15,11 @@
   <tbody>
     <% @users.each do |user| %>
       <tr>
+        <% if user.image.present? %>
+          <td><%= image_tag user.image.variant(resize: '30x30') %></td>
+        <% else %>
+          <td></td>
+        <% end %>
         <td><%= user.email %></td>
         <td><%= user.name %></td>
         <td><%= user.postal_code %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,7 +16,7 @@
     <% @users.each do |user| %>
       <tr>
         <% if user.image.present? %>
-          <td><%= image_tag user.image.variant(resize: '30x30') %></td>
+          <td><%= image_tag user.image.variant(resize_to_fill: [30, 30]) %></td>
         <% else %>
           <td></td>
         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,12 @@
 <h1><%= t('views.common.title_show', name: User.model_name.human) %></h1>
 
 <p>
+  <% if @user.image.present? %>
+    <%= image_tag @user.image.variant(resize: '100x100') %>
+  <% end %>
+</p>
+
+<p>
   <strong><%= User.human_attribute_name(:email) %>:</strong>
   <%= @user.email %>
 </p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <% if @user.image.present? %>
-    <%= image_tag @user.image.variant(resize: '100x100') %>
+    <%= image_tag @user.image.variant(resize_to_fill: [100, 100]) %>
   <% end %>
 </p>
 

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -11,6 +11,7 @@ ja:
         picture: 画像  #g
         title: 題名  #g
       user:
+        image: アイコン
         name: 氏名
         postal_code: 郵便番号
         address: 住所

--- a/db/migrate/20220205025251_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220205025251_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20220205025251_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220205025251_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
@@ -11,7 +13,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :checksum,     null: false
       t.datetime :created_at,   null: false
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments do |t|
@@ -21,7 +23,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index %i[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness', unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
@@ -29,7 +31,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.belongs_to :blob, null: false, index: false
       t.string :variation_digest, null: false
 
-      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.index %i[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end

--- a/db/migrate/20220205025251_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220205025251_create_active_storage_tables.active_storage.rb
@@ -33,6 +33,8 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.index %i[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
+
+      t.timestamps
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_31_231050) do
+ActiveRecord::Schema.define(version: 2022_02_05_025251) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -37,4 +65,6 @@ ActiveRecord::Schema.define(version: 2021_05_31_231050) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## 内容
* ActiveStorageを使ってユーザーアイコンの画像を登録できるようにしました。
* ユーザーアイコンに使えるファイルの拡張子はpng,jp(e)g,gifに絞ってあります。

## UI

### 一覧画面
![image](https://user-images.githubusercontent.com/20497053/152636201-7e0f72e3-93f2-41db-8755-965d1734018a.png)

### 詳細画面
![image](https://user-images.githubusercontent.com/20497053/152636235-42745d53-323d-436e-b3ad-488f6fcfd3be.png)

